### PR TITLE
Add skills.sh badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gitload 🦦
 
+[![skills.sh](https://skills.sh/b/waldekmastykarz/gitload)](https://skills.sh/waldekmastykarz/gitload)
+
 A beautiful CLI to download files, folders, or entire repositories from GitHub URLs.
 
 ## Use with AI agents


### PR DESCRIPTION
Adds a [skills.sh](https://skills.sh) install count badge to the README, making the skill discoverable and showing live install numbers.